### PR TITLE
Version stuff1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ haproxy-api
 *.swp
 *.swo
 docker/templates
+.idea/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apk --update add haproxy bash curl tar
 RUN cd / && curl -L https://github.com/just-containers/skaware/releases/download/v1.17.1/s6-eeb0f9098450dbe470fc9b60627d15df62b04239-linux-amd64-bin.tar.gz | tar -xvzf -
 
 # Set up haproxy-api
+ADD release-notes.txt /haproxy-api/release-notes.txt
 ADD haproxy-api /haproxy-api/haproxy-api
 ADD haproxy-api.toml /haproxy-api/haproxy-api.toml
 ADD templates /haproxy-api/templates

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,22 @@
+FROM golang:1.7-alpine
+# This must be run from the root of the package directory, e.g. $GOPATH/github.com/nitro/haproxy-api
+ARG VERSION=
+ARG GITHUB_TOKEN=
+ARG DOCKER_HOST=
+RUN apk --update add bash curl tar git docker file openssl
+RUN go get github.com/aktau/github-release &&  go get github.com/tools/godep
+
+ADD . src/github.com/nitro/haproxy-api
+
+WORKDIR /go/src/github.com/nitro/haproxy-api
+RUN docker/build.sh build
+WORKDIR /go/src/github.com/nitro/haproxy-api/docker
+
+RUN tar -czvf /haproxy-api-${VERSION}.tgz .
+RUN echo "release ${VERSION} /haproxy-api-${VERSION}.tgz"
+
+# docker build -t haproxy-api-build \
+# --build-arg DOCKER_HOST=192.168.168.167:2376 \
+# --build-arg VERSION=3142 \
+# --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
+# -f docker/Dockerfile.release .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,11 +1,80 @@
 #!/bin/bash
-
+BUILD_DATE=$(date -u '+%Y%m%d_%H_%M_%S')
+BUILD_VERSION=$(git describe --always)
+VERSION=${BUILD_VERSION}
+PACKAGE_DIR="${GOPATH}/src/github.com/nitro/haproxy-api/"
+BUILD_DOCKER_DIR="${PACKAGE_DIR}/docker/"
 die() {
 	echo $1
 	exit 1
 }
 
-file ../haproxy-api | grep "ELF.*LSB" || die "../haproxy-api is missing or not a Linux binary"
+get_deps() {
+  if [[ ! $(which github-release) ]]; then
+  go get github.com/aktau/github-release
+  fi
+}
 
-test -f haproxy-api.toml || cp haproxy-api.docker.toml haproxy-api.toml
-cp ../haproxy-api . && cp -pr ../templates . && docker build -t haproxy-api . || die "Failed to build"
+release_notes() {
+  rm  ${BUILD_DOCKER_DIR}/release-notes.txt
+  touch ${BUILD_DOCKER_DIR}/release-notes.txt
+  file ${PACKAGE_DIR}/haproxy-api > ${BUILD_DOCKER_DIR}/release-notes.txt
+  openssl md5 ${PACKAGE_DIR}/haproxy-api >> ${BUILD_DOCKER_DIR}/release-notes.txt
+  echo "GIT Tag or Hash:${BUILD_VERSION}" >> ${BUILD_DOCKER_DIR}/release-notes.txt
+}
+
+build() {
+  cd ${PACKAGE_DIR}
+  GOOS="linux" godep go build -ldflags="-X main.version=${VERSION}" && echo "build seems to have run..."
+  release_notes
+  cat ${BUILD_DOCKER_DIR}/release-notes.txt
+  test -f ${PACKAGE_DIR}/haproxy-api && file ${PACKAGE_DIR}/haproxy-api | grep "ELF.*LSB" || die "haproxy-api is missing or not a Linux binary"
+  test -f ${PACKAGE_DIR}/haproxy-api.toml && cp ${PACKAGE_DIR}/haproxy-api.toml ${BUILD_DOCKER_DIR}
+  cp ${PACKAGE_DIR}/haproxy-api ${BUILD_DOCKER_DIR} && cp -pr ${PACKAGE_DIR}/templates ${BUILD_DOCKER_DIR} || die "Failed to copy"
+}
+
+publish_docker() {
+  cd ${BUILD_DOCKER_DIR}
+  echo ${DOCKER_HOST}
+  docker build -q -t gonitro/haproxy-api:${VERSION} -f Dockerfile .  > last_build || die "Failed to build container"
+  cat last_build
+  # docker push gonitro/haproxy-api:${BUILD_VERSION}
+}
+
+release_github() {
+  echo "weelease the seecwat veapon! ${VERSION}"
+}
+
+release_docker() {
+  echo "pushing docker image ${VERSION}"
+
+}
+
+build_inside_docker() {
+ cd ${PACKAGE_DIR}
+ docker build -t haproxy-api-build \
+ --build-arg DOCKER_HOST=192.168.168.167:2376 \
+ --build-arg VERSION=3142 \
+ --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} \
+ -f docker/Dockerfile.release .
+ echo "now you might want to run: docker run -it --rm haproxy-api"
+}
+
+
+case ${1} in
+buildindocker)
+  build_inside_docker
+  ;;
+build)
+  build || die "build died oops."
+  publish_docker || die "publish docker died oops."
+  ;;
+release)
+  release_github
+  release_docker
+  ;;
+*)
+  echo "Usage: ${0} { build | release }"
+  exit 1
+  ;;
+esac

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -60,8 +60,16 @@ build_inside_docker() {
  echo "now you might want to run: docker run -it --rm haproxy-api"
 }
 
+clean_workspace() {
+cd ${PACKAGE_DIR}
+rm 	haproxy-api docker/haproxy-api.toml	docker/last_build docker/release-notes.txt release-notes.txt
+}
+
 
 case ${1} in
+clean)
+  clean_workspace
+  ;;
 buildindocker)
   build_inside_docker
   ;;

--- a/docker/check
+++ b/docker/check
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker exec haproxy-api curl http://localhost:7778/health

--- a/docker/run
+++ b/docker/run
@@ -2,6 +2,16 @@
 
 # Simple wrapper to docker to start the named image with the correct options
 
-IMAGE=$1
+if [[ ${1+x} ]]; then
+  IMAGE=$1
+elif [ -f last_build ]; then
+  echo "Use the last build"
+  IMAGE="$(cat last_build)"
+else
+ echo "${IMAGE}"
+ echo "You need to set an image Id"
+ exit 1
+fi
+
 echo "Starting from $IMAGE"
-docker run -i -t --label SidecarDiscover=false --net=host --name=haproxy-api $IMAGE
+docker run -i -t --label SidecarDiscover=false --rm --name=haproxy-api $IMAGE

--- a/docker/s6/services/haproxy-api.svc/run
+++ b/docker/s6/services/haproxy-api.svc/run
@@ -9,4 +9,5 @@ if [[ -n "$HAPROXYAPI_LOGGING_LEVEL" ]]; then
     sed -i.bak 's/logging_level *= *"info"/logging_level = "'"$HAPROXYAPI_LOGGING_LEVEL"'"/' haproxy-api.toml
 fi
 
+cat /haproxy-api/release-notes.txt
 exec ./haproxy-api -f haproxy-api.toml

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var (
 	currentState   *catalog.ServicesState
 	lastSvcChanged *service.Service
 	updateSuccess  bool
+	version        string = "Version not set!"
 )
 
 type CliOpts struct {
@@ -45,6 +46,7 @@ type ApiStatus struct {
 	Message        string           `json:"message"`
 	LastChanged    time.Time        `json:"last_changed"`
 	ServiceChanged *service.Service `json:"last_service_changed"`
+	Version	       string		`json:"version"`
 }
 
 func exitWithError(err error, message string) {
@@ -72,7 +74,7 @@ func run(command string) error {
 
 // The health check endpoint. Tells us if HAproxy is running and has
 // been properly configured. Since this is critical infrastructure this
-// helps make sure a host is not "down" by havign the proxy down.
+// helps make sure a host is not "down" by having the proxy down.
 func healthHandler(response http.ResponseWriter, req *http.Request) {
 	defer req.Body.Close()
 	response.Header().Set("Content-Type", "application/json")
@@ -82,6 +84,7 @@ func healthHandler(response http.ResponseWriter, req *http.Request) {
 	// Do we have an HAproxy instance running?
 	err := run("test -f " + proxy.PidFile + " && ps aux `cat " + proxy.PidFile + "`")
 	if err != nil {
+		errors = append(errors, version)
 		errors = append(errors, "No HAproxy running!")
 	}
 
@@ -110,6 +113,7 @@ func healthHandler(response http.ResponseWriter, req *http.Request) {
 		Message:        "Healthy!",
 		LastChanged:    lastChanged,
 		ServiceChanged: lastSvcChanged,
+		Version:	version,
 	})
 
 	response.Write(message)


### PR DESCRIPTION
Added some rudimentary version support for haproxy-api in order to get this into a proper build pipeline. @relistan @bparli @mihaitodor Inspired from this post https://blog.cloudflare.com/setting-go-variables-at-compile-time/

The health check now spits out the version that was set at compile time when running and even when healthcheck fails.

This also supports a docker in docker build for the mac or Jenkins.  
`$PACKAGE_DIR/docker/build.sh build` builds binary in local os for linux we may want to pass the GOOS=osx in this case.

`$PACKAGE_DIR/docker/build.sh buildindocker` uses a golang 1.7 alpine container which does the same build but in a consistent controlled environment ensuring proper godeps and gopath is used.  Hopefully preventing unicorn builds.

Also started work on a release function which uses [github-release](https://github.com/aktau/github-release) so we can publish the binaries on their own on github.