### PR TITLE
Update for newer HAproxy, newer Sidecar

### DIFF
--- a/follower.go
+++ b/follower.go
@@ -54,7 +54,7 @@ func generateUrls(opts *CliOpts, config *Config) (watchUrl string, stateUrl stri
 		if err != nil {
 			log.Fatalf("Unable to follow %s: %s", *opts.Follow, err)
 		}
-		stateTmp.Path = "/state.json"
+		stateTmp.Path = "/api/state.json"
 		stateUrl = stateTmp.String()
 
 		watchTmp, err := url.Parse("http://" + *opts.Follow)

--- a/templates/haproxy.cfg
+++ b/templates/haproxy.cfg
@@ -27,7 +27,7 @@ defaults
 frontend stats_proxy
 	mode http
 	bind 0.0.0.0:3212
-	rspadd Access-Control-Allow-Origin:\ *
+	http-request add-header Access-Control-Allow-Origin *
 	default_backend stats_proxy
 
 backend stats_proxy
@@ -41,7 +41,7 @@ frontend stats
 
 backend stats
 	mode http
-	rspadd Access-Control-Allow-Origin:\ *
+	http-request add-header Access-Control-Allow-Origin *
 	stats enable
 	stats uri /
 	stats refresh 5s


### PR DESCRIPTION
Hey Nitro folks, this is some small updates that support newer HAproxy, which doesn't allow `rspadd` any more, and newer Sidecar, which has moved the state endpoint under `/api`.